### PR TITLE
v.0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install https://github.com/Intron7/rapids_singlecell/releases/download/v0.2.
 
 With this enviroment, you should be able to run the notebooks. So far I have tested these Notebooks on an A100 80GB, a Quadro RTX 6000 and a RTX 3090.
 
-To view a full guide how to set up a fully functioned single cell GPU accelerated visit [GPU_SingleCell_Setup](https://github.com/Intron7/GPU_SingleCell_Setup)
+To view a full guide how to set up a fully functioned single cell GPU accelerated conda environment visit [GPU_SingleCell_Setup](https://github.com/Intron7/GPU_SingleCell_Setup)
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The functions are analogous versions of functions that can be found within [scan
 
 ## Requirements
 
-To run the code in this repository you need a conda environment with rapids and scanpy installed. To use the full functionality of this repo please use `rapids-22.04` or `rapids-22.06`. You also need an Nvidia GPU.
+To run the code in this repository you need a conda environment with rapids and scanpy installed. To use the full functionality of this repo please use `rapids-22.08`. You also need an Nvidia GPU.
 ```
 conda create -n rapids_singelcell -f conda/rapids_singecell.yml
 conda activate rapids_singelcell
@@ -14,10 +14,12 @@ ipython kernel install --user --name=rapids_singelcell
 ```
 After you set up the enviroment you can install this package from this wheel into the enviroment. The wheel doesn't install any dependencies
 ```
-pip install https://github.com/Intron7/rapids_singlecell/releases/download/v0.2.1/rapids_singlecell-0.2.1-py3-none-any.whl
+pip install https://github.com/Intron7/rapids_singlecell/releases/download/v0.2.2/rapids_singlecell-0.2.2-py3-none-any.whl
 ```
 
 With this enviroment, you should be able to run the notebooks. So far I have tested these Notebooks on an A100 80GB, a Quadro RTX 6000 and a RTX 3090.
+
+To view a full guide how to set up a fully functioned single cell GPU accelerated visit [GPU_SingleCell_Setup](https://github.com/Intron7/GPU_SingleCell_Setup)
 
 ## Citation
 

--- a/rapids_singlecell/__init__.py
+++ b/rapids_singlecell/__init__.py
@@ -1,4 +1,4 @@
 from . import cunnData
 from . import scanpy_gpu_funcs
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/rapids_singlecell/cunnData.py
+++ b/rapids_singlecell/cunnData.py
@@ -536,6 +536,7 @@ class cunnData:
         X = X - mu
         X = X / cp.sqrt( mu + mu**2 / theta)
         X = cp.clip(X, a_min=-clip, a_max=clip)
+        X = cp.array(X, dtype= cp.float32)
         if inplace == True:
             if layer:
                 self.layers[layer]= X

--- a/rapids_singlecell/scanpy_gpu_funcs.py
+++ b/rapids_singlecell/scanpy_gpu_funcs.py
@@ -22,6 +22,8 @@ from cuml.manifold import TSNE
 from cuml.cluster import KMeans
 from cuml.decomposition import PCA
 
+from scipy.sparse import issparse
+import warnings
 
 
 def _select_groups(labels, groups_order_subset='all'):
@@ -345,6 +347,11 @@ def pca(adata: AnnData,
          covariance matrix.
     """
     X = adata.layers[layer] if layer is not None else adata.X
+    if issparse(X):
+        warnings.warn(
+            "Your Countmatrix seems to be sparse, this can lead to a massive performance penalty.",
+            UserWarning,
+        )
     pca_func = PCA(n_components=n_comps, output_type="numpy")
     adata.obsm["X_pca"] = pca_func.fit_transform(X)
     adata.uns['pca'] ={'variance':pca_func.explained_variance_, 'variance_ratio':pca_func.explained_variance_ratio_}


### PR DESCRIPTION
fixed a bug where `normalize_pearson_residuals` counts had no assigned dtype