### PR TITLE
Rapids 23.06

### DIFF
--- a/conda/rsc_rapids_23.06.yml
+++ b/conda/rsc_rapids_23.06.yml
@@ -5,7 +5,7 @@ channels:
  - conda-forge
  - bioconda
 dependencies:
- - rapids=23.02
+ - rapids=23.06
  - python=3.10
  - cudatoolkit=11.8
  - cudnn

--- a/rapids_singlecell/__init__.py
+++ b/rapids_singlecell/__init__.py
@@ -5,4 +5,4 @@ from . import tl
 from . import pl
 from . import gr
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/rapids_singlecell/cunnData/__init__.py
+++ b/rapids_singlecell/cunnData/__init__.py
@@ -663,7 +663,7 @@ def _check_X(X):
 
 
 def _get_vector(cudata, k, coldim, idxdim, layer=None):
-    # cudata could be self if Raw and AnnData shared a parent
+    # cudata could be self
     dims = ("obs", "var")
     col = getattr(cudata, coldim).columns
     idx = getattr(cudata, f"{idxdim}_names")

--- a/rapids_singlecell/cunnData_funcs/_scale.py
+++ b/rapids_singlecell/cunnData_funcs/_scale.py
@@ -46,7 +46,7 @@ def scale(
     X /= stddev
     del stddev
     if max_value:
-        X = cp.clip(X, a_max=max_value)
+        X = cp.clip(X, a_min=-max_value, a_max=max_value)
     if inplace:
         if layer:
             cudata.layers[layer] = X

--- a/rapids_singlecell/scanpy_gpu/_clustering.py
+++ b/rapids_singlecell/scanpy_gpu/_clustering.py
@@ -1,6 +1,8 @@
 import cupy as cp
 import cudf
-import cugraph
+from cugraph import Graph
+from cugraph import leiden as culeiden
+from cugraph import louvain as culouvain
 import numpy as np
 import pandas as pd
 from cuml.cluster import KMeans
@@ -16,7 +18,7 @@ import warnings
 def leiden(
     adata: AnnData,
     resolution: float = 1.0,
-    n_iterations: int = -1,
+    n_iterations: int = 100,
     use_weights: bool = True,
     neighbors_key: Optional[int] = None,
     key_added: str = "leiden",
@@ -34,9 +36,9 @@ def leiden(
             Higher values lead to more clusters.
 
         n_iterations
-            How many iterations of the Leiden clustering algorithm to perform.
-            Positive values above 2 define the total number of iterations to perform,
-            -1 has the algorithm run until it reaches its optimal clustering.
+            This controls the maximum number of levels/iterations of the Louvain algorithm.
+            When specified the algorithm will terminate after no more than the specified number of iterations.
+            No error occurs when the algorithm terminates early in this manner.
 
         use_weights
             If `True`, edge weights from the graph are used in the computation
@@ -63,12 +65,12 @@ def leiden(
     else:
         weights = None
 
-    g = cugraph.Graph()
+    g = Graph()
 
     g.from_cudf_adjlist(offsets, indices, weights)
 
     # Cluster
-    leiden_parts, _ = cugraph.leiden(g, resolution=resolution, max_iter=n_iterations)
+    leiden_parts, _ = culeiden(g, resolution=resolution, max_iter=n_iterations)
 
     # Format output
     groups = (
@@ -138,12 +140,12 @@ def louvain(
     else:
         weights = None
 
-    g = cugraph.Graph()
+    g = Graph()
 
     g.from_cudf_adjlist(offsets, indices, weights)
 
     # Cluster
-    louvain_parts, _ = cugraph.louvain(g, resolution=resolution, max_iter=n_iterations)
+    louvain_parts, _ = culouvain(g, resolution=resolution, max_iter=n_iterations)
 
     # Format output
     groups = (


### PR DESCRIPTION
## Fixes for Rapids-23.06:
* added `a_min` to `cp.clip`  for `.pp.scale`
* changed default `n_iterations` for `leiden` to 100